### PR TITLE
Remove js code block start in README

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -21,8 +21,6 @@ const sheldonCooper = env.clownface()
 The main export includes `rdf-dataset-ext` package to extend the dataset's functionality. 
 This package may cause issues in the browser, so you can import the `@zazuko/env/web.js` instead.
 
-```js
-
 ## Additional features
 
 ### Dataset


### PR DESCRIPTION
While I was reading the README file, it appears that it was broken.
A `js` code block was started, but without code, and without end of that code block.
This was leading to a broken render of the README file.

I just removed that `js` code block start to fix the rendering.