### PR TITLE
feat: dataset utils

### DIFF
--- a/.changeset/nasty-camels-beam.md
+++ b/.changeset/nasty-camels-beam.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/env": minor
+---
+
+Added static utilities `toCanonical`, `toStream` and `fromStream` to dataset factory

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -25,6 +25,27 @@ This package may cause issues in the browser, so you can import the `@zazuko/env
 
 ### Dataset
 
+#### Static util functions
+
+The dataset factory implemented by the main module environment provides some static utility functions
+from the [rdf-dataset-ext](httos://npm.im/rdf-dataset-ext) package.
+
+```ts
+import { Stream, DatasetCore } from '@rdfjs/types'
+import env from '@zazuko/env'
+
+let stream: Stream
+
+// shorthand for creating a dataset from a stream
+const dataset: DatasetCore = await env.dataset.fromStream(stream)
+
+// stream any DatasetCore
+const streamFromCoreDataset: Stream = env.dataset.toStream(dataset)
+
+// convert any DatasetCore to a canonical form
+const canonicalQuads = env.dataset.toCanonical(dataset)
+```
+
 #### `rdf-ext` functionality
 
 The provided `DatasetCore` implementation provides additional methods, matching the `rdf-ext` interface.

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -1,5 +1,5 @@
 import Environment from './Environment.js'
-import DatasetFactory from './lib/DatasetFactory.js'
+import DatasetFactory from './lib/DatasetFactoryExt.js'
 import parent from './lib/env-no-dataset.js'
 import { createConstructor } from './lib/DatasetExt.js'
 

--- a/packages/env/lib/DatasetFactoryExt.ts
+++ b/packages/env/lib/DatasetFactoryExt.ts
@@ -1,0 +1,30 @@
+import type { Readable } from 'stream'
+import type { Stream } from '@rdfjs/types'
+import type { Environment } from '@rdfjs/environment/Environment.js'
+import { FormatsFactory } from '@rdfjs/formats/Factory.js'
+import DatasetCore from '@rdfjs/dataset/DatasetCore.js'
+import toStream from 'rdf-dataset-ext/toStream.js'
+import fromStream from 'rdf-dataset-ext/fromStream.js'
+import toCanonical from 'rdf-dataset-ext/toCanonical.js'
+import type { DatasetCtor } from './Dataset.js'
+import DatasetFactory, { FactoryMethod as BaseFactoryMethod } from './DatasetFactory.js'
+
+export interface FactoryMethod<D extends DatasetCore> extends BaseFactoryMethod<D> {
+  toCanonical: (quads: DatasetCore) => string
+  toStream: (quads: DatasetCore) => Readable & Stream
+  fromStream: (stream: Readable) => Promise<D>
+}
+
+export default <D extends DatasetCore>(createConstructor: (env: Environment<FormatsFactory>) => DatasetCtor<D>) => class DatasetFactoryExt extends DatasetFactory(createConstructor) {
+  public declare dataset: FactoryMethod<D>
+
+  init(this: Environment<FormatsFactory | DatasetFactoryExt>) {
+    super.init()
+
+    this.dataset.toCanonical = toCanonical
+    this.dataset.toStream = toStream
+    this.dataset.fromStream = (stream) => {
+      return fromStream(this.dataset(), stream)
+    }
+  }
+}

--- a/packages/env/test/index.test.ts
+++ b/packages/env/test/index.test.ts
@@ -3,7 +3,8 @@ import $rdf from '@rdfjs/data-model'
 import rdfDs from '@rdfjs/dataset'
 import prettyFormats from '@rdfjs-elements/formats-pretty'
 import toStream from 'rdf-dataset-ext/toStream.js'
-import { create, DefaultEnv } from '../index.js'
+import { getStreamAsArray } from 'get-stream'
+import env, { create, DefaultEnv } from '../index.js'
 import { Dataset } from '../lib/DatasetExt.js'
 
 declare module '../formats.js' {
@@ -262,5 +263,31 @@ _:b1 sh:path schema:name .
         })
       })
     }
+  })
+
+  describe('dataset factory ext', () => {
+    it('has toStream utility', async () => {
+      // given
+      const quad = $rdf.quad($rdf.namedNode('foo'), $rdf.namedNode('bar'), $rdf.namedNode('baz'))
+      const dataset = env.dataset([quad])
+
+      // when
+      const streamedQuads = await getStreamAsArray(env.dataset.toStream(dataset))
+
+      // then
+      expect(streamedQuads).to.deep.contain.members([quad])
+    })
+
+    it('has fromStream utility', async () => {
+      // given
+      const quad = $rdf.quad($rdf.namedNode('foo'), $rdf.namedNode('bar'), $rdf.namedNode('baz'))
+      const dataset = env.dataset([quad]).toStream()
+
+      // when
+      const streamedQuads = await env.dataset.fromStream(dataset)
+
+      // then
+      expect([...streamedQuads]).to.deep.contain.members([quad])
+    })
   })
 })

--- a/packages/env/test/index.test.ts
+++ b/packages/env/test/index.test.ts
@@ -3,7 +3,6 @@ import $rdf from '@rdfjs/data-model'
 import rdfDs from '@rdfjs/dataset'
 import prettyFormats from '@rdfjs-elements/formats-pretty'
 import toStream from 'rdf-dataset-ext/toStream.js'
-import { getStreamAsArray } from 'get-stream'
 import env, { create, DefaultEnv } from '../index.js'
 import { Dataset } from '../lib/DatasetExt.js'
 
@@ -272,22 +271,22 @@ _:b1 sh:path schema:name .
       const dataset = env.dataset([quad])
 
       // when
-      const streamedQuads = await getStreamAsArray(env.dataset.toStream(dataset))
+      const streamedQuads = await env.dataset.fromStream(env.dataset.toStream(dataset))
 
       // then
-      expect(streamedQuads).to.deep.contain.members([quad])
+      expect(env.dataset.toCanonical(streamedQuads)).to.eq(env.dataset.toCanonical(dataset))
     })
 
     it('has fromStream utility', async () => {
       // given
       const quad = $rdf.quad($rdf.namedNode('foo'), $rdf.namedNode('bar'), $rdf.namedNode('baz'))
-      const dataset = env.dataset([quad]).toStream()
+      const dataset = env.dataset([quad])
 
       // when
-      const streamedQuads = await env.dataset.fromStream(dataset)
+      const streamedQuads = await env.dataset.fromStream(dataset.toStream())
 
       // then
-      expect([...streamedQuads]).to.deep.contain.members([quad])
+      expect(env.dataset.toCanonical(streamedQuads)).to.eq(env.dataset.toCanonical(dataset))
     })
   })
 })


### PR DESCRIPTION
I often find myself need to stream a `DatasetCore`. That requires importing `rdf-dataset-ext` even though it's already a dependency of `@zazuko/env`

Thus, I added static methods to the `env.dataset` factory so that any dataset can be streamed

Also added `fromStream` and `toCanonical`